### PR TITLE
Makes Hierarchy.find type-safe

### DIFF
--- a/src/main/java/net/kyori/lunar/reflect/Hierarchy.java
+++ b/src/main/java/net/kyori/lunar/reflect/Hierarchy.java
@@ -26,9 +26,8 @@ package net.kyori.lunar.reflect;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Collections;
+import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.function.Predicate;
 
 /**
@@ -49,21 +48,26 @@ public final class Hierarchy {
    */
   // thanks, kenzie
   public static <T> @Nullable Class<? extends T> find(final @NonNull Class<? extends T> first, final @NonNull Class<T> type, final @NonNull Predicate<Class<? extends T>> predicate) {
-    final Deque<Class<?>> classes = new LinkedList<>();
+    final Deque<Class<? extends T>> classes = new ArrayDeque<>();
     classes.add(first);
 
     while(!classes.isEmpty()) {
-      final /* @Nullable */ Class<?> next = classes.removeFirst();
-      if(next == null || !type.isAssignableFrom(next)) {
-        continue;
+      final /* @Nullable */ Class<? extends T> next = classes.remove();
+
+      if(predicate.test(next)) {
+        return next;
       }
 
-      if(predicate.test((Class<? extends T>) next)) {
-        return (Class<? extends T>) next;
+      final /* @Nullable */ Class<?> parent = next.getSuperclass();
+      if(parent != null && type.isAssignableFrom(parent)) {
+        classes.add(parent.asSubclass(type));
       }
 
-      classes.add(next.getSuperclass());
-      Collections.addAll(classes, next.getInterfaces());
+      for(final /* @NonNull */ Class<?> interfaceType : next.getInterfaces()) {
+        if(type.isAssignableFrom(interfaceType)) {
+          classes.add(interfaceType.asSubclass(type));
+        }
+      }
     }
 
     return null;

--- a/src/test/java/net/kyori/lunar/reflect/HierarchyTest.java
+++ b/src/test/java/net/kyori/lunar/reflect/HierarchyTest.java
@@ -29,16 +29,20 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class HierarchyTest {
   @Test
   void testFind() {
     final List<Class<?>> classes = Arrays.asList(Thing1.class, ThingA.class);
     assertEquals(ThingA.class, Hierarchy.find(ThingB.class, Thing1.class, classes::contains));
+    assertEquals(Object.class, Hierarchy.find(ThingB.class, Object.class, c -> c == Object.class));
+    assertNull(Hierarchy.find(ThingB.class, Object.class, c -> c.getSuperclass() == Thing3.class));
   }
 
   private interface Thing1 {}
   private interface Thing2 {}
+  private interface Thing3 {}
   private static class ThingA implements Thing1 {}
   private static class ThingB extends ThingA implements Thing2 {}
 }


### PR DESCRIPTION
Added two more tests for the method, too.
This should be easily cherry-picked over to the master branch.
An array deque should be preferred over a linked list.